### PR TITLE
Fix VSCode Jest type errors & bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "homepage": "https://github.com/omnea-digital/interview-kata#readme",
   "dependencies": {
-    "@swc/core": "^1.3.6",
-    "@swc/jest": "^0.2.23",
-    "@types/jest": "^29.1.2",
-    "jest": "^29.1.2",
-    "prettier": "^2.7.1",
-    "typescript": "^4.8.4"
+    "@swc/core": "^1.15.41",
+    "@swc/jest": "^0.2.39",
+    "@types/jest": "^30.0.0",
+    "jest": "^30.4.2",
+    "prettier": "^3.8.4",
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "omnea-interview-kata",
   "version": "0.0.0",
   "description": "",
+  "private": true,
   "main": "index.js",
   "scripts": {
     "test": "jest --watchAll"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "ES2022",                                /* Specify what module code is generated. */
-     "rootDir": "./",                                  /* Specify the root folder within your source files. */
-     "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "module": "NodeNext",                                /* Specify what module code is generated. */
+    "rootDir": "./",                                     /* Specify the root folder within your source files. */
+    "moduleResolution": "nodenext",                      /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["jest"],                                   /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */


### PR DESCRIPTION
Fix Jest global function type errors that have been displaying in VSCode/Cursor etc. for candidates recently. Due to missing declaration in tsconfig `compilerOptions.types`. Some other small tsconfig updates too.

Also update all dependencies.

Verified with a small partial solution to the kata locally on Node 22, 24 & 26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and config-only changes for an interview kata repo; no application runtime logic is modified.
> 
> **Overview**
> Fixes **VSCode/Cursor Jest global type errors** (e.g. `describe`, `it`, `expect`) by setting `compilerOptions.types` to `["jest"]` in `tsconfig.json`, so `@types/jest` is loaded explicitly.
> 
> **TypeScript module settings** are updated from `ES2022` / `node` to **`NodeNext` / `nodenext`** for alignment with current Node ESM resolution.
> 
> **Dependencies** are bumped across the board (Jest 29→30, TypeScript 4.8→6, Prettier 2→3, SWC packages, `@types/jest` 29→30). **`private: true`** is added to `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a36d20f42e8c093b9d4b399325550a3230d41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes VSCode/Cursor Jest type errors by adding Jest types and aligning TypeScript module settings. Also bumps test/toolchain dependencies and marks the package `private`.

- **Bug Fixes**
  - Add `types: ["jest"]` to `tsconfig` to resolve global `describe/it/expect` errors.
  - Set `module: "NodeNext"` and `moduleResolution: "nodenext"` for compatibility with newer TypeScript/Jest.

- **Dependencies**
  - Update `jest` to `^30.4.2` and `@types/jest` to `^30.0.0`.
  - Update `typescript` to `^6.0.3` and `prettier` to `^3.8.4`.
  - Update `@swc/core` and `@swc/jest`.
  - Set `"private": true` in `package.json`.

<sup>Written for commit c0a36d20f42e8c093b9d4b399325550a3230d41a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/omnea-digital/interview-kata/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

