### PR TITLE
feat: implement kata problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Each rover will be finished sequentially, which means that the second rover won`
 the first one has finished moving.
 
 ### OUTPUT
+
 The output for each rover should be its final coordinates and heading.
 
 ### EXAMPLE
 
 Test Input:
+
 ```
 5 5
 1 2 N
@@ -43,9 +45,14 @@ MMRMMRMRRM
 ```
 
 Expected Output:
+
 ```
 1 3 N
 5 1 E
 ```
 
 ![](./compass.png)
+
+### SOLUTION
+
+A solution to this problem has been implemented in `index.ts`. In the interview, we'll improve and extend this implementation.

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,3 +1,287 @@
-test("init", () => {
-    expect(false).toBe(true)
-})
+import { Rover, Plateau, MarsRoverMission } from "./index";
+
+describe("Rover", () => {
+  let plateau: Plateau;
+
+  beforeEach(() => {
+    plateau = new Plateau(5, 5);
+  });
+
+  describe("initialization", () => {
+    it("should initialize with correct position and direction", () => {
+      const rover = new Rover(1, 2, "N");
+      expect(rover.getPosition()).toEqual({ x: 1, y: 2 });
+      expect(rover.getDirection()).toBe("N");
+    });
+
+    it("should have correct string representation", () => {
+      const rover = new Rover(1, 3, "N");
+      expect(rover.toString()).toBe("1 3 N");
+    });
+  });
+
+  describe("turning", () => {
+    it("should turn left from North to West", () => {
+      const rover = new Rover(0, 0, "N");
+      rover.turnLeft();
+      expect(rover.getDirection()).toBe("W");
+    });
+
+    it("should turn left from West to South", () => {
+      const rover = new Rover(0, 0, "W");
+      rover.turnLeft();
+      expect(rover.getDirection()).toBe("S");
+    });
+
+    it("should turn left from South to East", () => {
+      const rover = new Rover(0, 0, "S");
+      rover.turnLeft();
+      expect(rover.getDirection()).toBe("E");
+    });
+
+    it("should turn left from East to North", () => {
+      const rover = new Rover(0, 0, "E");
+      rover.turnLeft();
+      expect(rover.getDirection()).toBe("N");
+    });
+
+    it("should turn right from North to East", () => {
+      const rover = new Rover(0, 0, "N");
+      rover.turnRight();
+      expect(rover.getDirection()).toBe("E");
+    });
+
+    it("should turn right from East to South", () => {
+      const rover = new Rover(0, 0, "E");
+      rover.turnRight();
+      expect(rover.getDirection()).toBe("S");
+    });
+
+    it("should turn right from South to West", () => {
+      const rover = new Rover(0, 0, "S");
+      rover.turnRight();
+      expect(rover.getDirection()).toBe("W");
+    });
+
+    it("should turn right from West to North", () => {
+      const rover = new Rover(0, 0, "W");
+      rover.turnRight();
+      expect(rover.getDirection()).toBe("N");
+    });
+  });
+
+  describe("moving", () => {
+    it("should move north", () => {
+      const rover = new Rover(1, 2, "N");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 1, y: 3 });
+    });
+
+    it("should move south", () => {
+      const rover = new Rover(1, 2, "S");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 1, y: 1 });
+    });
+
+    it("should move east", () => {
+      const rover = new Rover(1, 2, "E");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 2, y: 2 });
+    });
+
+    it("should move west", () => {
+      const rover = new Rover(1, 2, "W");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 0, y: 2 });
+    });
+
+    it("should not move beyond upper-right boundary", () => {
+      const rover = new Rover(5, 5, "N");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 5, y: 5 });
+    });
+
+    it("should not move beyond left boundary", () => {
+      const rover = new Rover(0, 0, "W");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 0, y: 0 });
+    });
+
+    it("should not move beyond bottom boundary", () => {
+      const rover = new Rover(0, 0, "S");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 0, y: 0 });
+    });
+
+    it("should not move beyond right boundary", () => {
+      const rover = new Rover(5, 5, "E");
+      rover.moveForward(plateau);
+      expect(rover.getPosition()).toEqual({ x: 5, y: 5 });
+    });
+  });
+
+  describe("executing commands", () => {
+    it("should execute single turn left command", () => {
+      const rover = new Rover(0, 0, "N");
+      rover.executeCommands("L", plateau);
+      expect(rover.getDirection()).toBe("W");
+    });
+
+    it("should execute single turn right command", () => {
+      const rover = new Rover(0, 0, "N");
+      rover.executeCommands("R", plateau);
+      expect(rover.getDirection()).toBe("E");
+    });
+
+    it("should execute single move command", () => {
+      const rover = new Rover(0, 0, "N");
+      rover.executeCommands("M", plateau);
+      expect(rover.getPosition()).toEqual({ x: 0, y: 1 });
+    });
+
+    it("should execute sequence: LMLMLMLMM", () => {
+      const rover = new Rover(1, 2, "N");
+      rover.executeCommands("LMLMLMLMM", plateau);
+      expect(rover.toString()).toBe("1 3 N");
+    });
+
+    it("should execute sequence: MMRMMRMRRM", () => {
+      const rover = new Rover(3, 3, "E");
+      rover.executeCommands("MMRMMRMRRM", plateau);
+      expect(rover.toString()).toBe("5 1 E");
+    });
+
+    it("should ignore invalid commands", () => {
+      const rover = new Rover(0, 0, "N");
+      rover.executeCommands("LXMYL", plateau);
+      expect(rover.toString()).toBe("0 0 S");
+    });
+
+    it("should handle empty command string", () => {
+      const rover = new Rover(1, 2, "N");
+      rover.executeCommands("", plateau);
+      expect(rover.toString()).toBe("1 2 N");
+    });
+  });
+});
+
+describe("Plateau", () => {
+  it("should track boundaries correctly", () => {
+    const plateau = new Plateau(5, 5);
+    expect(plateau.getMaxX()).toBe(5);
+    expect(plateau.getMaxY()).toBe(5);
+  });
+
+  it("should verify bounds for origin", () => {
+    const plateau = new Plateau(5, 5);
+    expect(plateau.isWithinBounds(0, 0)).toBe(true);
+  });
+
+  it("should verify bounds for upper-right", () => {
+    const plateau = new Plateau(5, 5);
+    expect(plateau.isWithinBounds(5, 5)).toBe(true);
+  });
+
+  it("should reject coordinates beyond upper-right", () => {
+    const plateau = new Plateau(5, 5);
+    expect(plateau.isWithinBounds(6, 5)).toBe(false);
+    expect(plateau.isWithinBounds(5, 6)).toBe(false);
+  });
+
+  it("should reject negative coordinates", () => {
+    const plateau = new Plateau(5, 5);
+    expect(plateau.isWithinBounds(-1, 0)).toBe(false);
+    expect(plateau.isWithinBounds(0, -1)).toBe(false);
+  });
+});
+
+describe("MarsRoverMission", () => {
+  it("should create mission with correct plateau", () => {
+    const mission = new MarsRoverMission(5, 5);
+    expect(mission.getRoverPositions()).toEqual([]);
+  });
+
+  it("should add rovers to mission", () => {
+    const mission = new MarsRoverMission(5, 5);
+    const rover1 = new Rover(1, 2, "N");
+    const rover2 = new Rover(3, 3, "E");
+
+    mission.addRover(rover1);
+    mission.addRover(rover2);
+
+    expect(mission.getRoverPositions()).toEqual(["1 2 N", "3 3 E"]);
+  });
+
+  it("should execute commands for specific rover", () => {
+    const mission = new MarsRoverMission(5, 5);
+    const rover = new Rover(1, 2, "N");
+    mission.addRover(rover);
+
+    mission.executeRoverCommands(0, "LMLMLMLMM");
+    expect(mission.getRoverPositions()).toEqual(["1 3 N"]);
+  });
+
+  it("should handle multiple rovers independently", () => {
+    const mission = new MarsRoverMission(5, 5);
+    mission.addRover(new Rover(1, 2, "N"));
+    mission.addRover(new Rover(3, 3, "E"));
+
+    mission.executeRoverCommands(0, "LMLMLMLMM");
+    mission.executeRoverCommands(1, "MMRMMRMRRM");
+
+    expect(mission.getRoverPositions()).toEqual(["1 3 N", "5 1 E"]);
+  });
+
+  it("should not execute commands for invalid rover index", () => {
+    const mission = new MarsRoverMission(5, 5);
+    const rover = new Rover(0, 0, "N");
+    mission.addRover(rover);
+
+    mission.executeRoverCommands(5, "M");
+    expect(mission.getRoverPositions()).toEqual(["0 0 N"]);
+  });
+});
+
+describe("MarsRoverMission.parseInput", () => {
+  it("should parse example input correctly", () => {
+    const input = `5 5
+1 2 N
+LMLMLMLMM
+3 3 E
+MMRMMRMRRM`;
+
+    const mission = MarsRoverMission.parseInput(input);
+    expect(mission.getRoverOutput()).toBe(`1 3 N
+5 1 E`);
+  });
+
+  it("should parse single rover", () => {
+    const input = `5 5
+0 0 N
+MMM`;
+
+    const mission = MarsRoverMission.parseInput(input);
+    expect(mission.getRoverOutput()).toBe(`0 3 N`);
+  });
+
+  it("should handle input with extra whitespace", () => {
+    const input = `  5 5
+1 2 N
+LMLMLMLMM`;
+
+    const mission = MarsRoverMission.parseInput(input);
+    expect(mission.getRoverOutput()).toBe(`1 3 N`);
+  });
+
+  it("should handle multiple rovers in sequence", () => {
+    const input = `10 10
+0 0 N
+M
+5 5 E
+M`;
+
+    const mission = MarsRoverMission.parseInput(input);
+    expect(mission.getRoverOutput()).toBe(`0 1 N
+6 5 E`);
+  });
+});

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,158 @@
+type Direction = "N" | "S" | "E" | "W";
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+const DIRECTIONS: Direction[] = ["N", "E", "S", "W"];
+
+function getDirectionIndex(dir: Direction): number {
+  return DIRECTIONS.indexOf(dir);
+}
+
+function turnLeft(dir: Direction): Direction {
+  const index = getDirectionIndex(dir);
+  return DIRECTIONS[(index - 1 + 4) % 4];
+}
+
+function turnRight(dir: Direction): Direction {
+  const index = getDirectionIndex(dir);
+  return DIRECTIONS[(index + 1) % 4];
+}
+
+function getMovementVector(dir: Direction): [number, number] {
+  switch (dir) {
+    case "N":
+      return [0, 1];
+    case "S":
+      return [0, -1];
+    case "E":
+      return [1, 0];
+    case "W":
+      return [-1, 0];
+  }
+}
+
+export class Rover {
+  private position: Position;
+  private direction: Direction;
+
+  constructor(x: number, y: number, direction: Direction) {
+    this.position = { x, y };
+    this.direction = direction;
+  }
+
+  getPosition(): Position {
+    return { ...this.position };
+  }
+
+  getDirection(): Direction {
+    return this.direction;
+  }
+
+  turnLeft(): void {
+    this.direction = turnLeft(this.direction);
+  }
+
+  turnRight(): void {
+    this.direction = turnRight(this.direction);
+  }
+
+  moveForward(plateau: Plateau): void {
+    const [dx, dy] = getMovementVector(this.direction);
+    const newX = this.position.x + dx;
+    const newY = this.position.y + dy;
+
+    if (plateau.isWithinBounds(newX, newY)) {
+      this.position.x = newX;
+      this.position.y = newY;
+    }
+  }
+
+  executeCommands(commands: string, plateau: Plateau): void {
+    for (const command of commands) {
+      if (command === "L") {
+        this.turnLeft();
+      } else if (command === "R") {
+        this.turnRight();
+      } else if (command === "M") {
+        this.moveForward(plateau);
+      }
+    }
+  }
+
+  toString(): string {
+    return `${this.position.x} ${this.position.y} ${this.direction}`;
+  }
+}
+
+export class Plateau {
+  private maxX: number;
+  private maxY: number;
+
+  constructor(maxX: number, maxY: number) {
+    this.maxX = maxX;
+    this.maxY = maxY;
+  }
+
+  isWithinBounds(x: number, y: number): boolean {
+    return x >= 0 && x <= this.maxX && y >= 0 && y <= this.maxY;
+  }
+
+  getMaxX(): number {
+    return this.maxX;
+  }
+
+  getMaxY(): number {
+    return this.maxY;
+  }
+}
+
+export class MarsRoverMission {
+  private plateau: Plateau;
+  private rovers: Rover[] = [];
+
+  constructor(maxX: number, maxY: number) {
+    this.plateau = new Plateau(maxX, maxY);
+  }
+
+  addRover(rover: Rover): void {
+    this.rovers.push(rover);
+  }
+
+  executeRoverCommands(roverIndex: number, commands: string): void {
+    if (roverIndex >= 0 && roverIndex < this.rovers.length) {
+      this.rovers[roverIndex].executeCommands(commands, this.plateau);
+    }
+  }
+
+  getRoverPositions(): string[] {
+    return this.rovers.map((rover) => rover.toString());
+  }
+
+  getRoverOutput(): string {
+    return this.getRoverPositions().join("\n");
+  }
+
+  static parseInput(input: string): MarsRoverMission {
+    const lines = input.trim().split("\n");
+    const [maxX, maxY] = lines[0].split(" ").map(Number);
+    const mission = new MarsRoverMission(maxX, maxY);
+
+    for (let i = 1; i < lines.length; i += 2) {
+      const positionLine = lines[i].split(" ");
+      const x = Number(positionLine[0]);
+      const y = Number(positionLine[1]);
+      const direction = positionLine[2] as Direction;
+
+      const rover = new Rover(x, y, direction);
+      mission.addRover(rover);
+
+      const commands = lines[i + 1];
+      mission.executeRoverCommands(mission.rovers.length - 1, commands);
+    }
+
+    return mission;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Interview kata code and tests only; no production services, auth, or data paths.
> 
> **Overview**
> Adds a **full Mars Rover kata solution** in `index.ts`: `Rover` (turn, move with plateau bounds, `L`/`R`/`M` commands), `Plateau` (rectangular limits), and `MarsRoverMission` to run rovers sequentially plus **`parseInput`** for multi-line mission text and **`getRoverOutput`** for final positions.
> 
> Replaces the placeholder Jest test with a **broad suite** covering turns, movement, edges, command sequences (including the README example), invalid commands, mission orchestration, and `parseInput` (whitespace, multiple rovers).
> 
> **README** gets light formatting around examples and a **SOLUTION** section noting `index.ts` as the interview starting point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e3fa1c0ef83fef14816220ac19344ae9a926c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implements the Mars Rover kata with core classes, an input parser, and bounded movement logic; adds comprehensive tests and a README note pointing to the solution.

- New Features
  - Adds `Rover`, `Plateau`, and `MarsRoverMission` with L/R/M command execution and boundary checks.
  - Introduces `MarsRoverMission.parseInput` to read the spec format and `getRoverOutput` to print final positions.
  - Updates README to reference `index.ts`; tests cover turning, movement limits, command sequences, whitespace, and invalid inputs.

<sup>Written for commit 3e3fa1c0ef83fef14816220ac19344ae9a926c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/omnea-digital/interview-kata/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

