### PR TITLE
Implement kata problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ drive your solution out test-first.
 
 > Looking for the `uv` + `ruff`/`ty` toolchain instead? See the
 > [`python-astral`](https://github.com/omnea-digital/interview-kata/tree/python-astral) branch.
+
+## SOLUTION
+
+A solution to this problem has been implemented in `index.py`. In the interview, we'll improve and extend this implementation.

--- a/index.py
+++ b/index.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, cast
+
+Direction = Literal["N", "S", "E", "W"]
+
+
+@dataclass(frozen=True)
+class Position:
+    x: int
+    y: int
+
+
+DIRECTIONS: list[Direction] = ["N", "E", "S", "W"]
+
+
+def _turn_left(direction: Direction) -> Direction:
+    index = DIRECTIONS.index(direction)
+    return DIRECTIONS[(index - 1) % 4]
+
+
+def _turn_right(direction: Direction) -> Direction:
+    index = DIRECTIONS.index(direction)
+    return DIRECTIONS[(index + 1) % 4]
+
+
+def _movement_vector(direction: Direction) -> tuple[int, int]:
+    match direction:
+        case "N":
+            return (0, 1)
+        case "S":
+            return (0, -1)
+        case "E":
+            return (1, 0)
+        case "W":
+            return (-1, 0)
+
+
+class Plateau:
+    def __init__(self, max_x: int, max_y: int) -> None:
+        self._max_x = max_x
+        self._max_y = max_y
+
+    @property
+    def max_x(self) -> int:
+        return self._max_x
+
+    @property
+    def max_y(self) -> int:
+        return self._max_y
+
+    def is_within_bounds(self, x: int, y: int) -> bool:
+        return 0 <= x <= self._max_x and 0 <= y <= self._max_y
+
+
+class Rover:
+    def __init__(self, x: int, y: int, direction: Direction) -> None:
+        self._position = Position(x, y)
+        self._direction: Direction = direction
+
+    @property
+    def position(self) -> Position:
+        return self._position
+
+    @property
+    def direction(self) -> Direction:
+        return self._direction
+
+    def turn_left(self) -> None:
+        self._direction = _turn_left(self._direction)
+
+    def turn_right(self) -> None:
+        self._direction = _turn_right(self._direction)
+
+    def move_forward(self, plateau: Plateau) -> None:
+        dx, dy = _movement_vector(self._direction)
+        new_x = self._position.x + dx
+        new_y = self._position.y + dy
+
+        if plateau.is_within_bounds(new_x, new_y):
+            self._position = Position(new_x, new_y)
+
+    def execute_commands(self, commands: str, plateau: Plateau) -> None:
+        for command in commands:
+            if command == "L":
+                self.turn_left()
+            elif command == "R":
+                self.turn_right()
+            elif command == "M":
+                self.move_forward(plateau)
+
+    def __str__(self) -> str:
+        return f"{self._position.x} {self._position.y} {self._direction}"
+
+
+class MarsRoverMission:
+    def __init__(self, max_x: int, max_y: int) -> None:
+        self._plateau = Plateau(max_x, max_y)
+        self._rovers: list[Rover] = []
+
+    def add_rover(self, rover: Rover) -> None:
+        self._rovers.append(rover)
+
+    def execute_rover_commands(self, rover_index: int, commands: str) -> None:
+        if 0 <= rover_index < len(self._rovers):
+            self._rovers[rover_index].execute_commands(commands, self._plateau)
+
+    def get_rover_positions(self) -> list[str]:
+        return [str(rover) for rover in self._rovers]
+
+    def get_rover_output(self) -> str:
+        return "\n".join(self.get_rover_positions())
+
+    @staticmethod
+    def parse_input(input_text: str) -> MarsRoverMission:
+        lines = input_text.strip().split("\n")
+        max_x, max_y = (int(value) for value in lines[0].split(" "))
+        mission = MarsRoverMission(max_x, max_y)
+
+        for i in range(1, len(lines), 2):
+            x_token, y_token, direction_token = lines[i].split(" ")
+            direction = cast(Direction, direction_token)
+
+            rover = Rover(int(x_token), int(y_token), direction)
+            mission.add_rover(rover)
+
+            commands = lines[i + 1]
+            mission.execute_rover_commands(len(mission._rovers) - 1, commands)
+
+        return mission

--- a/index_test.py
+++ b/index_test.py
@@ -1,2 +1,230 @@
-def test_init() -> None:
-    assert False
+import pytest
+
+from index import MarsRoverMission, Plateau, Position, Rover
+
+
+class TestRover:
+    @pytest.fixture
+    def plateau(self) -> Plateau:
+        return Plateau(5, 5)
+
+    class TestInitialization:
+        def test_initializes_with_correct_position_and_direction(self) -> None:
+            rover = Rover(1, 2, "N")
+            assert rover.position == Position(1, 2)
+            assert rover.direction == "N"
+
+        def test_has_correct_string_representation(self) -> None:
+            rover = Rover(1, 3, "N")
+            assert str(rover) == "1 3 N"
+
+    class TestTurning:
+        def test_turns_left_from_north_to_west(self) -> None:
+            rover = Rover(0, 0, "N")
+            rover.turn_left()
+            assert rover.direction == "W"
+
+        def test_turns_left_from_west_to_south(self) -> None:
+            rover = Rover(0, 0, "W")
+            rover.turn_left()
+            assert rover.direction == "S"
+
+        def test_turns_left_from_south_to_east(self) -> None:
+            rover = Rover(0, 0, "S")
+            rover.turn_left()
+            assert rover.direction == "E"
+
+        def test_turns_left_from_east_to_north(self) -> None:
+            rover = Rover(0, 0, "E")
+            rover.turn_left()
+            assert rover.direction == "N"
+
+        def test_turns_right_from_north_to_east(self) -> None:
+            rover = Rover(0, 0, "N")
+            rover.turn_right()
+            assert rover.direction == "E"
+
+        def test_turns_right_from_east_to_south(self) -> None:
+            rover = Rover(0, 0, "E")
+            rover.turn_right()
+            assert rover.direction == "S"
+
+        def test_turns_right_from_south_to_west(self) -> None:
+            rover = Rover(0, 0, "S")
+            rover.turn_right()
+            assert rover.direction == "W"
+
+        def test_turns_right_from_west_to_north(self) -> None:
+            rover = Rover(0, 0, "W")
+            rover.turn_right()
+            assert rover.direction == "N"
+
+    class TestMoving:
+        def test_moves_north(self, plateau: Plateau) -> None:
+            rover = Rover(1, 2, "N")
+            rover.move_forward(plateau)
+            assert rover.position == Position(1, 3)
+
+        def test_moves_south(self, plateau: Plateau) -> None:
+            rover = Rover(1, 2, "S")
+            rover.move_forward(plateau)
+            assert rover.position == Position(1, 1)
+
+        def test_moves_east(self, plateau: Plateau) -> None:
+            rover = Rover(1, 2, "E")
+            rover.move_forward(plateau)
+            assert rover.position == Position(2, 2)
+
+        def test_moves_west(self, plateau: Plateau) -> None:
+            rover = Rover(1, 2, "W")
+            rover.move_forward(plateau)
+            assert rover.position == Position(0, 2)
+
+        def test_does_not_move_beyond_upper_right_boundary(self, plateau: Plateau) -> None:
+            rover = Rover(5, 5, "N")
+            rover.move_forward(plateau)
+            assert rover.position == Position(5, 5)
+
+        def test_does_not_move_beyond_left_boundary(self, plateau: Plateau) -> None:
+            rover = Rover(0, 0, "W")
+            rover.move_forward(plateau)
+            assert rover.position == Position(0, 0)
+
+        def test_does_not_move_beyond_bottom_boundary(self, plateau: Plateau) -> None:
+            rover = Rover(0, 0, "S")
+            rover.move_forward(plateau)
+            assert rover.position == Position(0, 0)
+
+        def test_does_not_move_beyond_right_boundary(self, plateau: Plateau) -> None:
+            rover = Rover(5, 5, "E")
+            rover.move_forward(plateau)
+            assert rover.position == Position(5, 5)
+
+    class TestExecutingCommands:
+        def test_executes_single_turn_left_command(self, plateau: Plateau) -> None:
+            rover = Rover(0, 0, "N")
+            rover.execute_commands("L", plateau)
+            assert rover.direction == "W"
+
+        def test_executes_single_turn_right_command(self, plateau: Plateau) -> None:
+            rover = Rover(0, 0, "N")
+            rover.execute_commands("R", plateau)
+            assert rover.direction == "E"
+
+        def test_executes_single_move_command(self, plateau: Plateau) -> None:
+            rover = Rover(0, 0, "N")
+            rover.execute_commands("M", plateau)
+            assert rover.position == Position(0, 1)
+
+        def test_executes_sequence_lmlmlmlmm(self, plateau: Plateau) -> None:
+            rover = Rover(1, 2, "N")
+            rover.execute_commands("LMLMLMLMM", plateau)
+            assert str(rover) == "1 3 N"
+
+        def test_executes_sequence_mmrmmrmrrm(self, plateau: Plateau) -> None:
+            rover = Rover(3, 3, "E")
+            rover.execute_commands("MMRMMRMRRM", plateau)
+            assert str(rover) == "5 1 E"
+
+        def test_ignores_invalid_commands(self, plateau: Plateau) -> None:
+            rover = Rover(0, 0, "N")
+            rover.execute_commands("LXMYL", plateau)
+            assert str(rover) == "0 0 S"
+
+        def test_handles_empty_command_string(self, plateau: Plateau) -> None:
+            rover = Rover(1, 2, "N")
+            rover.execute_commands("", plateau)
+            assert str(rover) == "1 2 N"
+
+
+class TestPlateau:
+    def test_tracks_boundaries_correctly(self) -> None:
+        plateau = Plateau(5, 5)
+        assert plateau.max_x == 5
+        assert plateau.max_y == 5
+
+    def test_verifies_bounds_for_origin(self) -> None:
+        plateau = Plateau(5, 5)
+        assert plateau.is_within_bounds(0, 0) is True
+
+    def test_verifies_bounds_for_upper_right(self) -> None:
+        plateau = Plateau(5, 5)
+        assert plateau.is_within_bounds(5, 5) is True
+
+    def test_rejects_coordinates_beyond_upper_right(self) -> None:
+        plateau = Plateau(5, 5)
+        assert plateau.is_within_bounds(6, 5) is False
+        assert plateau.is_within_bounds(5, 6) is False
+
+    def test_rejects_negative_coordinates(self) -> None:
+        plateau = Plateau(5, 5)
+        assert plateau.is_within_bounds(-1, 0) is False
+        assert plateau.is_within_bounds(0, -1) is False
+
+
+class TestMarsRoverMission:
+    def test_creates_mission_with_correct_plateau(self) -> None:
+        mission = MarsRoverMission(5, 5)
+        assert mission.get_rover_positions() == []
+
+    def test_adds_rovers_to_mission(self) -> None:
+        mission = MarsRoverMission(5, 5)
+        rover1 = Rover(1, 2, "N")
+        rover2 = Rover(3, 3, "E")
+
+        mission.add_rover(rover1)
+        mission.add_rover(rover2)
+
+        assert mission.get_rover_positions() == ["1 2 N", "3 3 E"]
+
+    def test_executes_commands_for_specific_rover(self) -> None:
+        mission = MarsRoverMission(5, 5)
+        rover = Rover(1, 2, "N")
+        mission.add_rover(rover)
+
+        mission.execute_rover_commands(0, "LMLMLMLMM")
+        assert mission.get_rover_positions() == ["1 3 N"]
+
+    def test_handles_multiple_rovers_independently(self) -> None:
+        mission = MarsRoverMission(5, 5)
+        mission.add_rover(Rover(1, 2, "N"))
+        mission.add_rover(Rover(3, 3, "E"))
+
+        mission.execute_rover_commands(0, "LMLMLMLMM")
+        mission.execute_rover_commands(1, "MMRMMRMRRM")
+
+        assert mission.get_rover_positions() == ["1 3 N", "5 1 E"]
+
+    def test_does_not_execute_commands_for_invalid_rover_index(self) -> None:
+        mission = MarsRoverMission(5, 5)
+        rover = Rover(0, 0, "N")
+        mission.add_rover(rover)
+
+        mission.execute_rover_commands(5, "M")
+        assert mission.get_rover_positions() == ["0 0 N"]
+
+
+class TestParseInput:
+    def test_parses_example_input_correctly(self) -> None:
+        input_text = "5 5\n1 2 N\nLMLMLMLMM\n3 3 E\nMMRMMRMRRM"
+
+        mission = MarsRoverMission.parse_input(input_text)
+        assert mission.get_rover_output() == "1 3 N\n5 1 E"
+
+    def test_parses_single_rover(self) -> None:
+        input_text = "5 5\n0 0 N\nMMM"
+
+        mission = MarsRoverMission.parse_input(input_text)
+        assert mission.get_rover_output() == "0 3 N"
+
+    def test_handles_input_with_extra_whitespace(self) -> None:
+        input_text = "  5 5\n1 2 N\nLMLMLMLMM"
+
+        mission = MarsRoverMission.parse_input(input_text)
+        assert mission.get_rover_output() == "1 3 N"
+
+    def test_handles_multiple_rovers_in_sequence(self) -> None:
+        input_text = "10 10\n0 0 N\nM\n5 5 E\nM"
+
+        mission = MarsRoverMission.parse_input(input_text)
+        assert mission.get_rover_output() == "0 1 N\n6 5 E"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Interview kata code and tests only; no production services, auth, or data paths.
> 
> **Overview**
> Adds a **complete Mars Rover kata implementation** in `index.py`: typed `Rover` / `Plateau` / `MarsRoverMission` types, L/R/M command handling with plateau bounds, multi-rover orchestration, and `parse_input` for the kata text format.
> 
> Replaces the **failing placeholder** in `index_test.py` with a broad **pytest** suite (turning, movement, boundaries, missions, and parse examples including the README case).
> 
> The **README** gains a short **SOLUTION** note pointing interviewers at `index.py` as the baseline to extend in session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4431f7287e1178b871db1a96ba3ffc2903320699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete Mars Rover kata implementation with mission parsing, rover movement, and boundary checks, plus a comprehensive test suite.
Also updates the README to note the included solution.

- New Features
  - `Plateau`: tracks max X/Y and validates coordinates.
  - `Rover`: turns left/right, moves within bounds, executes command strings, and stringifies as "x y D".
  - `MarsRoverMission`: manages multiple rovers, parses input text, runs commands, and outputs final positions.
  - `Position` dataclass for immutable coordinates.

<sup>Written for commit 4431f7287e1178b871db1a96ba3ffc2903320699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/omnea-digital/interview-kata/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

